### PR TITLE
amount should not be converted to_cents

### DIFF
--- a/lib/active_merchant/billing/gateways/flow.rb
+++ b/lib/active_merchant/billing/gateways/flow.rb
@@ -171,7 +171,7 @@ module ActiveMerchant
 
       def assert_currency currency, amount
         raise ArgumentError, 'currency not provided' unless currency
-        currency_model = FlowCommerce::Reference::Currencies.find! currency
+        FlowCommerce::Reference::Currencies.find! currency
         amount.to_f
       end
     end


### PR DESCRIPTION
Expectation is that the `amount` in the `refund_form` is not converted `to_cents` (10 * `number of decimals`), but is rather sent in as a float.  

Keeping the currency code check, then return amount as is.